### PR TITLE
Fix to allow PCs to edit effects on items that were never unidentified

### DIFF
--- a/utility/utility_effects_advanced.xml
+++ b/utility/utility_effects_advanced.xml
@@ -12,7 +12,7 @@
         <script>
             function onInit()
                 local node = getDatabaseNode();
-                local bIDentified = DB.getValue(node, "isidentified", 0) > 0;
+                local bIDentified = DB.getValue(node, "isidentified", 1) > 0;
                 local bPCEdit = OptionsManager.isOption("ADND_AE_EDIT", "enabled");
                 local bIsPcItem = string.match(node.getPath(),"^charsheet") ~= null;
                 local bCanEdit = false;


### PR DESCRIPTION
By default new items don't add an entry in the DB for identification. When there is no value FG assumes that the item is identified. The Init function `utility_effects_advanced.xml` should assume when there is no `isidentified` that it should default to `1` for Identified.