### PR TITLE
Remove flag that only gm's can edit numbers

### DIFF
--- a/utility/template_utility_advanced.xml
+++ b/utility/template_utility_advanced.xml
@@ -164,7 +164,6 @@
         <basicnumber>
             <default>0</default>
             <hideonvalue>0</hideonvalue>
-            <gmeditonly />
         </basicnumber>
     </template>
 


### PR DESCRIPTION
I found players were unable to edit stats using the easy editors. Upon digging for some reason the number field is flagged as GM Edit only?