### PR TITLE
Fix for identified items applying effects as GM only

### DIFF
--- a/scripts/manager_AE.lua
+++ b/scripts/manager_AE.lua
@@ -655,7 +655,7 @@ function updateItemEffects(nodeItem)
 	end
 
 	local bEquipped = DB.getValue(nodeItem, "carried") == 2;
-	local bIdentified = DB.getValue(nodeItem, "isidentified") == 1;
+	local bIdentified = DB.getValue(nodeItem, "isidentified", 1) == 1;
 	-- local bOptionID = OptionsManager.isOption("MIID", "on");
 	-- if not bOptionID then 
 		-- bIdentified = true;


### PR DESCRIPTION
Its that pesky "no field should default to 1" for `isidentified` again. I don't know why if the default behavior for identification isn't a field like `unidentified` and defaulting to 0 would mean it was identified.