### PR TITLE
Fixes for February's changes

### DIFF
--- a/campaign/scripts/char_weapon_AE.lua
+++ b/campaign/scripts/char_weapon_AE.lua
@@ -9,9 +9,8 @@ function onDamageChanged()
 	local nodeChar = DB.getChild(nodeWeapon, "...")
 	local rActor = ActorManager.resolveActor(nodeChar)
 
-	local aDamage = {}
-	local aDamageNodes = UtilityManager.getSortedTable(DB.getChildren(nodeWeapon, "damagelist"))
-	for _, v in ipairs(aDamageNodes) do
+	local tDamage = {}
+	for _, v in ipairs(UtilityManager.getNodeSortedChildren(nodeWeapon, "damagelist")) do
 		local aDice = DB.getValue(v, "dice", {})
 		local nMod = DB.getValue(v, "bonus", 0)
 
@@ -45,9 +44,9 @@ function onDamageChanged()
 			if sType ~= "" then
 				sDamage = sDamage .. " " .. sType
 			end
-			table.insert(aDamage, sDamage)
+			table.insert(tDamage, sDamage)
 		end
 	end
 
-	damageview.setValue(table.concat(aDamage, "\n+ "))
+	button_damage.setTooltipText(string.format("%s: %s", Interface.getString("action_damage_tag"), table.concat(tDamage, " + ")));
 end

--- a/campaign/scripts/char_weapon_AE.lua
+++ b/campaign/scripts/char_weapon_AE.lua
@@ -9,8 +9,9 @@ function onDamageChanged()
 	local nodeChar = DB.getChild(nodeWeapon, "...")
 	local rActor = ActorManager.resolveActor(nodeChar)
 
-	local tDamage = {}
-	for _, v in ipairs(UtilityManager.getNodeSortedChildren(nodeWeapon, "damagelist")) do
+	local aDamage = {}
+	local aDamageNodes = UtilityManager.getNodeSortedChildren(nodeWeapon, "damagelist")
+	for _,v in ipairs(aDamageNodes) do
 		local aDice = DB.getValue(v, "dice", {})
 		local nMod = DB.getValue(v, "bonus", 0)
 
@@ -44,9 +45,9 @@ function onDamageChanged()
 			if sType ~= "" then
 				sDamage = sDamage .. " " .. sType
 			end
-			table.insert(tDamage, sDamage)
+			table.insert(aDamage, sDamage)
 		end
 	end
 
-	button_damage.setTooltipText(string.format("%s: %s", Interface.getString("action_damage_tag"), table.concat(tDamage, " + ")));
+	damageview.setValue(table.concat(aDamage, "\n+ "))
 end

--- a/extension.xml
+++ b/extension.xml
@@ -30,7 +30,7 @@
 		<includefile source="utility/utility_effects_advanced.xml" />
 
 		<includefile source="campaign/record_char_abilities.xml" />
-		<includefile source="campaign/record_char_actions.xml" />
+		<!-- <includefile source="campaign/record_char_actions.xml" /> -->
 		<includefile source="campaign/record_char_combat.xml" />
 		<includefile source="campaign/record_char.xml" />
 		<includefile source="campaign/record_item.xml" />

--- a/extension.xml
+++ b/extension.xml
@@ -30,7 +30,7 @@
 		<includefile source="utility/utility_effects_advanced.xml" />
 
 		<includefile source="campaign/record_char_abilities.xml" />
-		<!-- <includefile source="campaign/record_char_actions.xml" /> -->
+		<includefile source="campaign/record_char_actions.xml" />
 		<includefile source="campaign/record_char_combat.xml" />
 		<includefile source="campaign/record_char.xml" />
 		<includefile source="campaign/record_item.xml" />

--- a/extension.xml
+++ b/extension.xml
@@ -3,7 +3,7 @@
 <root version="3.0" >
 	<properties>
 		<name>Feature: Advanced Effects</name>
-		<version>1.22</version>
+		<version>1.23</version>
 		<author>Celestian</author>
 		<ported_by>rmilmine and bmos</ported_by>
 		<description>Add effects to pcs, npcs and items</description>


### PR DESCRIPTION
copy and pasted in the latest changes from the 3.5 ruleset for `onDamageChanged()`

I also removed `record_char_actions.xml` since it doesn't seem to be used. The only option for a non stat is `-` rather than `base` which is used in weapon attacks, not damage. Not sure if this logic is needed for attacks instead?

Ultimately I think `record_char_actions.xml`, `effects_list_AE.lua` and `char_weapon_AE.lua` can be deleted as they look to be unused or will be unused.

