### PR TITLE
Fix for CUSTOM conditionals where the condition is on a weapon

### DIFF
--- a/campaign/scripts/char_weapon_AE.lua
+++ b/campaign/scripts/char_weapon_AE.lua
@@ -3,7 +3,7 @@
 -- attribution and copyright information.
 --
 
--- luacheck: globals onDamageChanged
+-- luacheck: globals onDamageChanged button_damage
 function onDamageChanged()
 	local nodeWeapon = getDatabaseNode()
 	local nodeChar = DB.getChild(nodeWeapon, '...')

--- a/scripts/manager_AE.lua
+++ b/scripts/manager_AE.lua
@@ -712,11 +712,11 @@ function onInit()
 		EffectManager35E.getEffectsByType = getEffectsByType_new
 		EffectManager35E.hasEffect = hasEffect_new
 		EffectManager35E.hasEffectCondition = hasEffectCondition_new
+		EffectManager35E.checkConditionalHelper = checkConditionalHelper_new
 		ActionDamage.notifyApplyDamage = notifyApplyDamage
 		ActionDamage.handleApplyDamage = handleApplyDamage
 		OOBManager.registerOOBMsgHandler(ActionDamage.OOB_MSGTYPE_APPLYDMG, handleApplyDamage)
 	end
-	EffectManager35E.checkConditionalHelper = checkConditionalHelper_new
 
 	-- option in house rule section, enable/disable allow PCs to edit advanced effects.
 	OptionsManager.registerOption2('ADND_AE_EDIT', false, 'option_header_houserule', 'option_label_ADND_AE_EDIT', 'option_entry_cycler', {

--- a/scripts/manager_AE.lua
+++ b/scripts/manager_AE.lua
@@ -293,52 +293,52 @@ end
 
 function checkConditionalHelper_new(rActor, sEffect, rTarget, aIgnore)
 	if not rActor then
-		return false;
+		return false
 	end
-	
+
 	local aEffects
 	if TurboManager then
 		aEffects = TurboManager.getMatchedEffects(rActor, sEffectType)
 	else
 		aEffects = DB.getChildList(ActorManager.getCTNode(rActor), 'effects')
 	end
-	for _,v in ipairs(aEffects) do
+	for _, v in ipairs(aEffects) do
 		if isValidCheckEffect(rActor, v) and not StringManager.contains(aIgnore, DB.getPath(v)) then
 			-- Parse each effect label
-			local sLabel = DB.getValue(v, "label", "");
-			local aEffectComps = EffectManager.parseEffect(sLabel);
+			local sLabel = DB.getValue(v, 'label', '')
+			local aEffectComps = EffectManager.parseEffect(sLabel)
 
 			-- Iterate through each effect component looking for a type match
-			for _,sEffectComp in ipairs(aEffectComps) do
-				local rEffectComp = EffectManager35E.parseEffectComp(sEffectComp);
-				
+			for _, sEffectComp in ipairs(aEffectComps) do
+				local rEffectComp = EffectManager35E.parseEffectComp(sEffectComp)
+
 				--Check conditionals
-				if rEffectComp.type == "IF" then
+				if rEffectComp.type == 'IF' then
 					if not EffectManager35E.checkConditional(rActor, v, rEffectComp.remainder, nil, aIgnore) then
-						break;
+						break
 					end
-				elseif rEffectComp.type == "IFT" then
+				elseif rEffectComp.type == 'IFT' then
 					if not rTarget then
-						break;
+						break
 					end
 					if not EffectManager35E.checkConditional(rTarget, v, rEffectComp.remainder, rActor, aIgnore) then
-						break;
+						break
 					end
-				
+
 				-- Check for match
 				elseif rEffectComp.original:lower() == sEffect then
 					if EffectManager.isTargetedEffect(v) then
 						if EffectManager.isEffectTarget(v, rTarget) then
-							return true;
+							return true
 						end
 					else
-						return true;
+						return true
 					end
 				end
 			end
 		end
 	end
-	return false;
+	return false
 end
 
 -- this will be used to manage PC/NPC effectslist objects

--- a/scripts/manager_AE.lua
+++ b/scripts/manager_AE.lua
@@ -292,7 +292,6 @@ local function getEffectsByType_new(rActor, sEffectType, aFilter, rFilterActor, 
 end
 
 function checkConditionalHelper_new(rActor, sEffect, rTarget, aIgnore)
-	Debug.chat('checkConditionalHelper_new', rActor, sEffect, rTarget, aIgnore)
 	if not rActor then
 		return false;
 	end

--- a/scripts/manager_AE.lua
+++ b/scripts/manager_AE.lua
@@ -7,7 +7,7 @@
 -- Effects on Items, apply to character in CT
 --
 
--- luacheck: globals CombatManagerKel hasEffectCondition_new notifyApplyDamage TurboManager
+-- luacheck: globals CombatManagerKel hasEffectCondition_new TurboManager checkConditionalHelper_new
 local function sendRawMessage(sUser, nGMOnly, msg)
 	local sIdentity = nil
 	if sUser and sUser ~= '' then

--- a/scripts/manager_AE.lua
+++ b/scripts/manager_AE.lua
@@ -298,7 +298,7 @@ function checkConditionalHelper_new(rActor, sEffect, rTarget, aIgnore)
 
 	local aEffects
 	if TurboManager then
-		aEffects = TurboManager.getMatchedEffects(rActor, sEffectType)
+		aEffects = TurboManager.getMatchedEffects(rActor, sEffect)
 	else
 		aEffects = DB.getChildList(ActorManager.getCTNode(rActor), 'effects')
 	end


### PR DESCRIPTION
Fixes https://github.com/FG-Unofficial-Developers-Guild/FG-PFRPG-Advanced-Effects/issues/14

Simply doing the same isValidCheckEffect() call when iterating effects to check conditionals solves the problem. Shame there's no "getActiveEffects()" to modify instead.

Equivilant fix in Kel's Extended Automation: https://github.com/Kelrugem/Extended-automation-and-overlays/pull/33